### PR TITLE
Fix rendering of collapsed annotation at offset zero.

### DIFF
--- a/packages/slate/src/models/text.js
+++ b/packages/slate/src/models/text.js
@@ -194,7 +194,7 @@ class Text extends Record(DEFAULTS) {
           }
 
           // If the range starts after the leaf, or ends before it, continue.
-          if (start.offset > offset + length || end.offset <= offset) {
+          if (start.offset > offset + length || end.offset < offset || (end.offset === offset && offset !== 0)) {
             next.push(leaf)
             continue
           }


### PR DESCRIPTION
This is a fix for missing collaborative cursor at offset zero (beginning of the node).