### PR TITLE
Tighten mark addition logic against zero-length marks.

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -60,10 +60,12 @@ Commands.addMarkAtRange = (editor, range, mark) => {
       let index = 0
       let length = node.text.length
 
-      if (key === start.key) index = start.offset
       if (key === end.key) length = end.offset
-      if (key === start.key && key === end.key)
-        length = end.offset - start.offset
+
+      if (key === start.key) {
+        index = start.offset
+        length -= start.offset
+      }
 
       editor.addMarkByKey(key, index, length, mark)
     })

--- a/packages/slate/src/commands/by-path.js
+++ b/packages/slate/src/commands/by-path.js
@@ -39,6 +39,12 @@ Commands.addMarksByPath = (editor, path, offset, length, marks) => {
   const { document } = value
   const node = document.assertNode(path)
 
+  // Adding zero-length mark makes only sense on zero-length node, otherwise
+  // it will be pruned by normalization anyway.
+  if (length === 0 && node.text.length > 0) {
+    return
+  }
+
   editor.withoutNormalizing(() => {
     // If it ends before the end of the node, we'll need to split to create a new
     // text with different marks.


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
